### PR TITLE
Ruleset Population + Player Count Functionality

### DIFF
--- a/client/src/pages/HostPage.vue
+++ b/client/src/pages/HostPage.vue
@@ -21,9 +21,9 @@
 
         <q-select
           filled
-          v-model="model"
+          v-model="this.model"
           label="Ruleset"
-          :options="stringOptions"
+          :options="this.rulesetOptions"
           behavior="menu"
         />
 
@@ -62,7 +62,6 @@ import { defineComponent } from "vue";
 import { ref } from "vue";
 import { api } from "boot/axios";
 
-const stringOptions = ["Secret Hitler"];
 const minPlayer = 5;
 const maxPlayer = 10;
 
@@ -72,15 +71,10 @@ export default defineComponent({
   setup() {
     const name = ref(null);
     const playerNum = ref(null);
-    const options = ref(stringOptions);
-    const model = ref("Secret Hitler");
 
     return {
       name,
       playerNum,
-      model,
-      stringOptions,
-      options,
       minPlayer,
       maxPlayer,
 
@@ -90,7 +84,35 @@ export default defineComponent({
       },
     };
   },
+
+  data () {
+    return {
+      rulesetOptions: ["Secret Hitler"],
+      model: "Secret Hitler",
+    }
+  },
+
+  mounted() {
+    this.fetchRulesets();
+  },
+
   methods: {
+    fetchRulesets() {
+      api.get("/room/rulesets")
+        .then((res) => {
+        this.rulesetOptions = res.data;
+        this.model = res.data[0];
+      })
+        .catch((e) => {
+          this.$q.notify({
+            color: "negative",
+            textColor: "white",
+            icon: "report_problem",
+            message: "Request failed.",
+          });
+        })
+    },
+
     onSubmit(userName, ruleset, playerNum) {
       api
         .put("/room", {

--- a/client/src/pages/HostPage.vue
+++ b/client/src/pages/HostPage.vue
@@ -37,8 +37,8 @@
             (val) =>
               (val !== null && val !== '') || 'Please select amount of players',
             (val) =>
-              (val >= minPlayer && val <= maxPlayer) ||
-              `Please select within ${minPlayer} ➡️ ${maxPlayer} players`,
+              (val >= this.rulesets[this.model].minCount && val <= this.rulesets[this.model].maxCount) ||
+              `Please select within ${this.rulesets[this.model].minCount} ➡️ ${this.rulesets[this.model].maxCount} players`,
           ]"
         />
 
@@ -62,8 +62,6 @@ import { defineComponent } from "vue";
 import { ref } from "vue";
 import { api } from "boot/axios";
 
-const minPlayer = 5;
-const maxPlayer = 10;
 
 export default defineComponent({
   name: "HostPage",
@@ -75,8 +73,6 @@ export default defineComponent({
     return {
       name,
       playerNum,
-      minPlayer,
-      maxPlayer,
 
       onReset() {
         name.value = null;

--- a/client/src/pages/HostPage.vue
+++ b/client/src/pages/HostPage.vue
@@ -110,11 +110,12 @@ export default defineComponent({
           });
         })
         .catch((e) => {
+          const error = e.response ? e.response.data.errorMessage : "Request Failed."
           this.$q.notify({
             color: "negative",
             textColor: "white",
             icon: "report_problem",
-            message: e.response.data.errorMessage,
+            message: error,
           });
         });
     },

--- a/client/src/pages/HostPage.vue
+++ b/client/src/pages/HostPage.vue
@@ -114,9 +114,8 @@ export default defineComponent({
             color: "negative",
             textColor: "white",
             icon: "report_problem",
-            message: "Request failed.",
+            message: e.response.data.errorMessage,
           });
-          console.log(e);
         });
     },
   },

--- a/client/src/pages/HostPage.vue
+++ b/client/src/pages/HostPage.vue
@@ -87,6 +87,7 @@ export default defineComponent({
 
   data () {
     return {
+      rulesets: {},
       rulesetOptions: ["Secret Hitler"],
       model: "Secret Hitler",
     }
@@ -100,8 +101,9 @@ export default defineComponent({
     fetchRulesets() {
       api.get("/room/rulesets")
         .then((res) => {
-        this.rulesetOptions = res.data;
-        this.model = res.data[0];
+        this.rulesets = res.data;
+        this.rulesetOptions = Object.keys(this.rulesets);
+        this.model = this.rulesetOptions[0];
       })
         .catch((e) => {
           this.$q.notify({

--- a/client/src/pages/JoinPage.vue
+++ b/client/src/pages/JoinPage.vue
@@ -92,9 +92,8 @@ export default {
             color: "negative",
             textColor: "white",
             icon: "report_problem",
-            message: "Request failed.",
+            message: e.response.data.errorMessage,
           });
-          console.log(e);
         });
     },
   },

--- a/client/src/pages/JoinPage.vue
+++ b/client/src/pages/JoinPage.vue
@@ -88,11 +88,12 @@ export default {
           });
         })
         .catch((e) => {
+          const error = e.response ? e.response.data.errorMessage : "Request Failed."
           this.$q.notify({
             color: "negative",
             textColor: "white",
             icon: "report_problem",
-            message: e.response.data.errorMessage,
+            message: error,
           });
         });
     },

--- a/client/src/pages/LobbyPage.vue
+++ b/client/src/pages/LobbyPage.vue
@@ -11,7 +11,7 @@
               <q-item-label></q-item-label>
             </q-item-section>
           </q-item>
-          <q-item-label header>Player List</q-item-label>
+          <q-item-label header>{{ `Player Count: ${this.players.length}/${this.roomSize}` }}</q-item-label>
 
           <q-separator spaced />
 
@@ -67,6 +67,7 @@ export default {
   data() {
     return {
       players: [],
+      roomSize: 10,
     };
   },
 
@@ -81,7 +82,8 @@ export default {
       socketIo.connect();
       socketIo.on("send-data", (lobbyData) => {
         console.log(lobbyData);
-        this.players = lobbyData;
+        this.players = lobbyData.players;
+        this.roomSize = lobbyData.roomSize;
       });
       socketIo.on("invalid-user", (message) => {
         this.$router.push("/");

--- a/server/room-router.js
+++ b/server/room-router.js
@@ -39,10 +39,15 @@ router.put('/', async (req, res) => {  // room
 	}
 
 	// Make sure player count is valid.
-	const playerCount = RULESETS[room.ruleset].playerCounts
-	if (req.body.playerCount < playerCount.minCount || req.body.playerCount > playerCount.maxCount) {
-		res.status(422)
-		return res.send("Player count invalid.")
+	const ruleset = new RULESETS[room.ruleset];
+	const req_playerCount = parseInt(req.body.playerCount);
+	if (!req_playerCount) {
+		res.status(400);
+		return res.send();
+	}
+	if (req.body.playerCount < ruleset.playerCounts.minCount || req.body.playerCount > ruleset.playerCounts.maxCount) {
+		res.status(422);
+		return res.send("Player count invalid.");
 	}
 	
 	room.dateCreated = new Date() ?? null;

--- a/server/room-router.js
+++ b/server/room-router.js
@@ -45,6 +45,7 @@ router.put('/', async (req, res) => {  // room
 		res.status(400);
 		return res.send({errorMessage: "Bad request."});
 	}
+	// TODO: Try removing playerCounts and accessing mincount and maxcount straight away.
 	if (playerCount < ruleset.playerCounts.minCount || playerCount > ruleset.playerCounts.maxCount) {
 		res.status(422);
 		return res.send({errorMessage: "Player count invalid."});
@@ -106,7 +107,12 @@ router.put('/join', async (req, res) => {
 });
 
 router.get('/rulesets', async (req, res) => {
-	return res.send(Object.keys(RULESETS));
+	let result = {}
+	for (let rulesetName in RULESETS) {
+		const ruleset = new RULESETS[rulesetName];
+		result[rulesetName] = ruleset.playerCounts;
+	}
+	return res.send(result);
 });
 
 // TODO: Finish this endpoint, hook up web sockets to disperse role information.

--- a/server/room-router.js
+++ b/server/room-router.js
@@ -76,14 +76,19 @@ router.put('/join', async (req, res) => {
 		res.status(404);
 		return res.send("Room not found!")
 	}
-	
-	/* Check if duplicate username exists and send error if so */
+
 	const userName = normalizeUsername(req.body.userName);
 	const playerQuery = await playerRepository.search().where('roomId').equals(room.entityId).all();
 	let existingPlayers = []
-	playerQuery.forEach((p) => {
-		existingPlayers.push(p.entityFields.userName._value.toLowerCase());
-	});
+	for (let p in playerQuery) {
+		existingPlayers.push(playerQuery[p].userName.toLowerCase());
+	}
+	// Check if room is full
+	if (existingPlayers.length === room.playerCount) {
+		res.status(409);
+		return res.send("Room is full!");
+	}
+	// Check if username is already taken
 	if (existingPlayers.includes(userName.toLowerCase())) {
 		res.status(409);
 		return res.send("Username is already taken!")

--- a/server/room-router.js
+++ b/server/room-router.js
@@ -6,7 +6,7 @@ import { SecretHitler } from "./rulesets.js";
 
 export const router = Router()
 const MAX_TTL = 21600; // expiration time to live to be used by generated objects in seconds.
-const RULESETS = ["Secret Hitler", "Undefined Ruleset"];
+const RULESETS = {"Secret Hitler": SecretHitler}
 
 router.put('/', async (req, res) => {  // room
     let room = roomRepository.createEntity();
@@ -31,13 +31,11 @@ router.put('/', async (req, res) => {  // room
 	
 	/* check user input and match to ruleset
 	** if no user input exists, default to first index in ruleset */
-	for(let i = 0; i < RULESETS.length; i++) {
-		if (req.body.ruleset === RULESETS[i]) {
-			room.ruleset = req.body.ruleset ?? null;
-		}
-		else {
-			room.ruleset = RULESETS[0] ?? null;
-		}
+	if (RULESETS[req.body.ruleset]) {
+		room.ruleset = req.body.ruleset ?? null;
+	}
+	else {
+		room.ruleset = Object.keys(RULESETS)[0] ?? null;
 	}
 	
 	room.dateCreated = new Date() ?? null;

--- a/server/room-router.js
+++ b/server/room-router.js
@@ -105,6 +105,10 @@ router.put('/join', async (req, res) => {
 	return res.send({roomCode, userName, playerId})
 });
 
+router.get('/rulesets', async (req, res) => {
+	return res.send(Object.keys(RULESETS));
+});
+
 // TODO: Finish this endpoint, hook up web sockets to disperse role information.
 router.put('/start', async (req, res) => {
 	let player = await playerRepository.fetch(req.body.playerId);

--- a/server/room-router.js
+++ b/server/room-router.js
@@ -40,16 +40,17 @@ router.put('/', async (req, res) => {  // room
 
 	// Make sure player count is valid.
 	const ruleset = new RULESETS[room.ruleset];
-	const req_playerCount = parseInt(req.body.playerCount);
-	if (!req_playerCount) {
+	const playerCount = parseInt(req.body.playerCount);
+	if (!playerCount) {
 		res.status(400);
 		return res.send();
 	}
-	if (req_playerCount < ruleset.playerCounts.minCount || req_playerCount > ruleset.playerCounts.maxCount) {
+	if (playerCount < ruleset.playerCounts.minCount || playerCount > ruleset.playerCounts.maxCount) {
 		res.status(422);
 		return res.send("Player count invalid.");
 	}
-	
+
+	room.playerCount = playerCount ?? null;
 	room.dateCreated = new Date() ?? null;
 	room.dateEnd = getTTLDate(room.dateCreated, MAX_TTL) ?? null;
 	const roomId = await roomRepository.save(room);  //async
@@ -63,9 +64,6 @@ router.put('/', async (req, res) => {  // room
     const playerId = await playerRepository.save(player)
 	await playerRepository.expire(playerId, MAX_TTL)
 
-    // return res.send({roomId, playerId});  //debug
-
-	// const players = await playerRepository.search().where('roomId').equals(roomId).sortBy('dateJoined').all()
 	return res.send({roomCode, userName, playerId});
 
 });

--- a/server/room-router.js
+++ b/server/room-router.js
@@ -37,6 +37,13 @@ router.put('/', async (req, res) => {  // room
 	else {
 		room.ruleset = Object.keys(RULESETS)[0] ?? null;
 	}
+
+	// Make sure player count is valid.
+	const playerCount = RULESETS[room.ruleset].playerCounts
+	if (req.body.playerCount < playerCount.minCount || req.body.playerCount > playerCount.maxCount) {
+		res.status(422)
+		return res.send("Player count invalid.")
+	}
 	
 	room.dateCreated = new Date() ?? null;
 	room.dateEnd = getTTLDate(room.dateCreated, MAX_TTL) ?? null;

--- a/server/room-router.js
+++ b/server/room-router.js
@@ -45,7 +45,7 @@ router.put('/', async (req, res) => {  // room
 		res.status(400);
 		return res.send();
 	}
-	if (req.body.playerCount < ruleset.playerCounts.minCount || req.body.playerCount > ruleset.playerCounts.maxCount) {
+	if (req_playerCount < ruleset.playerCounts.minCount || req_playerCount > ruleset.playerCounts.maxCount) {
 		res.status(422);
 		return res.send("Player count invalid.");
 	}

--- a/server/room-router.js
+++ b/server/room-router.js
@@ -20,7 +20,7 @@ router.put('/', async (req, res) => {  // room
 	while (await roomRepository.search().where('roomName').equals(roomCode).first()) {
 		if (counter > 100) {
 			res.status(508);
-			return res.send("approaching infinite loop");
+			return res.send({errorMessage: "approaching infinite loop"});
 		}
 		else {
 			roomCode = makeRoomCode();
@@ -43,11 +43,11 @@ router.put('/', async (req, res) => {  // room
 	const playerCount = parseInt(req.body.playerCount);
 	if (!playerCount) {
 		res.status(400);
-		return res.send();
+		return res.send({errorMessage: "Bad request."});
 	}
 	if (playerCount < ruleset.playerCounts.minCount || playerCount > ruleset.playerCounts.maxCount) {
 		res.status(422);
-		return res.send("Player count invalid.");
+		return res.send({errorMessage: "Player count invalid."});
 	}
 
 	room.playerCount = playerCount ?? null;
@@ -74,7 +74,7 @@ router.put('/join', async (req, res) => {
 	const room = await roomRepository.search().where('roomName').equals(roomCode).first();
 	if (!room) {
 		res.status(404);
-		return res.send("Room not found!")
+		return res.send({errorMessage: "Room not found!"})
 	}
 
 	const userName = normalizeUsername(req.body.userName);
@@ -86,12 +86,12 @@ router.put('/join', async (req, res) => {
 	// Check if room is full
 	if (existingPlayers.length === room.playerCount) {
 		res.status(409);
-		return res.send("Room is full!");
+		return res.send({errorMessage: "Room is full!"});
 	}
 	// Check if username is already taken
 	if (existingPlayers.includes(userName.toLowerCase())) {
 		res.status(409);
-		return res.send("Username is already taken!")
+		return res.send({errorMessage: "Username is already taken!"})
 	}
 
 	let player = playerRepository.createEntity();

--- a/server/room.js
+++ b/server/room.js
@@ -5,6 +5,7 @@ class Room extends Entity {}
 const roomSchema = new Schema(Room, {
     roomName: {type: 'string'},
     ruleset: {type: 'string'},
+    playerCount: {type: 'number'},
 	dateCreated: {type: 'date'},
 	dateEnd: {type: 'date'},
 });

--- a/server/rulesets.js
+++ b/server/rulesets.js
@@ -86,7 +86,7 @@ export class SecretHitler {
         }
 		else {
 			playerRoles.push({playerId: players[0].entityId, RoleType: "Hitler", color: "maroon",
-							 message: `${players[0].userName}, your Secret Role is Hitler. Your fellow Fascists: ` })
+							 message: `${players[0].userName}, your Secret Role is Hitler.` })
 		}
 		
 		

--- a/server/rulesets.js
+++ b/server/rulesets.js
@@ -5,9 +5,6 @@ export class SecretHitler {
         this.players = players;
         this.minPlayers = 5;
         this.maxPlayers = 10;
-        if (this.players.length < this.minPlayers || this.players.length > this.maxPlayers) {
-            throw Error("That boy ain't right....");
-        }
     }
 
     get playerCounts () {

--- a/server/rulesets.js
+++ b/server/rulesets.js
@@ -10,6 +10,10 @@ export class SecretHitler {
         }
     }
 
+    get playerCounts () {
+        return {minCount: this.minPlayers, maxCount: this.maxPlayers}
+    }
+
     determineRoleCount(playerCount) {
         let liberalCount;
         let fascistCount;

--- a/server/server.js
+++ b/server/server.js
@@ -55,7 +55,7 @@ io.on("connect", async (socket) => {
         socket.join(room.roomName);
         let lobbyData = await playerRepository.search().where('roomId').equals(room.entityId).sortBy('dateJoined', 'ASC').all();
 
-        io.to(room.roomName).emit("send-data", playersOut(lobbyData));
+        io.to(room.roomName).emit("send-data", {players: playersOut(lobbyData), roomSize: room.playerCount});
     }
     socket.on("disconnect", async (reason) => {
         let player = await playerRepository.fetch(socket.playerId)
@@ -80,7 +80,7 @@ io.on("connect", async (socket) => {
             socket.leave(room.roomName);
 
             let lobbyData = await playerRepository.search().where('roomId').equals(room.entityId).sortBy('dateJoined', 'ASC').all();
-            io.to(room.roomName).emit("send-data", playersOut(lobbyData));
+            io.to(room.roomName).emit("send-data", {players: playersOut(lobbyData), roomSize: room.playerCount});
         }
     });
 });


### PR DESCRIPTION
- [X] Send player count to the server
- [X] Save player count per room in the room object
- [X] Validate number of players in room when player joins
- [X] Display player count on client.
- [X] Other refactors that may be good or bad 🤷🏻‍♂️

Now that we have ruleset classes, we should remove the hard-coded options on the client and fetch the possible rulesets from the server.

* Added endpoint for sending down rulesets.
* Client will now fetch rulesets and verify valid player count from returned data.